### PR TITLE
feat(challenges): "The verdict" — reorder by outcome + add Debos hiring case study

### DIFF
--- a/app/components/challengeCard.templ
+++ b/app/components/challengeCard.templ
@@ -21,7 +21,11 @@ templ ChallengeCard(challenge constants.Challenge) {
 			<div>
 				<h3 class="text-xl font-semibold">{ challenge.Title }</h3>
 				<p class="mt-1 font-mono text-sm text-zinc-500">
-					{ challenge.Dates } · { fmt.Sprintf("%d %s", challenge.Duration, dayWord(i18n.T(ctx), challenge.Duration)) }
+					if challenge.Duration > 0 {
+						{ challenge.Dates } · { fmt.Sprintf("%d %s", challenge.Duration, dayWord(i18n.T(ctx), challenge.Duration)) }
+					} else {
+						{ challenge.Dates }
+					}
 				</p>
 			</div>
 			if challenge.Highlight && challenge.State != "" {
@@ -33,19 +37,21 @@ templ ChallengeCard(challenge constants.Challenge) {
 		if challenge.Description != "" {
 			<p class="max-w-prose text-zinc-300">{ challenge.Description }</p>
 		}
-		<footer class="flex flex-wrap gap-3 pt-1">
-			if string(challenge.RepoLink) != "" {
-				@LinkItem(challenge.RepoLink, "inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-sm text-zinc-300 transition-colors hover:bg-white/5") {
-					<span>{ i18n.T(ctx).ChallengeRepository }</span>
-					@icons.GithubIcon(4)
+		if string(challenge.RepoLink) != "" || string(challenge.AppLink) != "" {
+			<footer class="flex flex-wrap gap-3 pt-1">
+				if string(challenge.RepoLink) != "" {
+					@LinkItem(challenge.RepoLink, "inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-sm text-zinc-300 transition-colors hover:bg-white/5") {
+						<span>{ i18n.T(ctx).ChallengeRepository }</span>
+						@icons.GithubIcon(4)
+					}
 				}
-			}
-			if string(challenge.AppLink) != "" {
-				@LinkItem(challenge.AppLink, "inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-sm text-zinc-300 transition-colors hover:bg-white/5") {
-					<span>{ i18n.T(ctx).ChallengeLiveDemo }</span>
-					@icons.OpenNewTabIcon()
+				if string(challenge.AppLink) != "" {
+					@LinkItem(challenge.AppLink, "inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-sm text-zinc-300 transition-colors hover:bg-white/5") {
+						<span>{ i18n.T(ctx).ChallengeLiveDemo }</span>
+						@icons.OpenNewTabIcon()
+					}
 				}
-			}
-		</footer>
+			</footer>
+		}
 	</article>
 }

--- a/app/components/challengeCard_templ.go
+++ b/app/components/challengeCard_templ.go
@@ -61,27 +61,39 @@ func ChallengeCard(challenge constants.Challenge) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(challenge.Dates)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 24, Col: 22}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(" · ")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d %s", challenge.Duration, dayWord(i18n.T(ctx), challenge.Duration)))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 24, Col: 112}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
+		if challenge.Duration > 0 {
+			var templ_7745c5c3_Var3 string
+			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(challenge.Dates)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 25, Col: 23}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(" · ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var4 string
+			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d %s", challenge.Duration, dayWord(i18n.T(ctx), challenge.Duration)))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 25, Col: 113}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else {
+			var templ_7745c5c3_Var5 string
+			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(challenge.Dates)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 27, Col: 23}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p></div>")
 		if templ_7745c5c3_Err != nil {
@@ -92,12 +104,12 @@ func ChallengeCard(challenge constants.Challenge) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var5 string
-			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(challenge.State)
+			var templ_7745c5c3_Var6 string
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(challenge.State)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 29, Col: 22}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 33, Col: 22}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -115,12 +127,12 @@ func ChallengeCard(challenge constants.Challenge) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(challenge.Description)
+			var templ_7745c5c3_Var7 string
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(challenge.Description)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 34, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 38, Col: 63}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -129,93 +141,99 @@ func ChallengeCard(challenge constants.Challenge) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<footer class=\"flex flex-wrap gap-3 pt-1\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if string(challenge.RepoLink) != "" {
-			templ_7745c5c3_Var7 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-				if !templ_7745c5c3_IsBuffer {
-					defer func() {
-						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-						if templ_7745c5c3_Err == nil {
-							templ_7745c5c3_Err = templ_7745c5c3_BufErr
-						}
-					}()
-				}
-				ctx = templ.InitializeContext(ctx)
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<span>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var8 string
-				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx).ChallengeRepository)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 39, Col: 44}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</span>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = icons.GithubIcon(4).Render(ctx, templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
+		if string(challenge.RepoLink) != "" || string(challenge.AppLink) != "" {
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<footer class=\"flex flex-wrap gap-3 pt-1\">")
+			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
-			})
-			templ_7745c5c3_Err = LinkItem(challenge.RepoLink, "inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-sm text-zinc-300 transition-colors hover:bg-white/5").Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
+			}
+			if string(challenge.RepoLink) != "" {
+				templ_7745c5c3_Var8 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+					templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+					templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+					if !templ_7745c5c3_IsBuffer {
+						defer func() {
+							templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+							if templ_7745c5c3_Err == nil {
+								templ_7745c5c3_Err = templ_7745c5c3_BufErr
+							}
+						}()
+					}
+					ctx = templ.InitializeContext(ctx)
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<span>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var9 string
+					templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx).ChallengeRepository)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 44, Col: 45}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</span>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = icons.GithubIcon(4).Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					return templ_7745c5c3_Err
+				})
+				templ_7745c5c3_Err = LinkItem(challenge.RepoLink, "inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-sm text-zinc-300 transition-colors hover:bg-white/5").Render(templ.WithChildren(ctx, templ_7745c5c3_Var8), templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			if string(challenge.AppLink) != "" {
+				templ_7745c5c3_Var10 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+					templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+					templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+					if !templ_7745c5c3_IsBuffer {
+						defer func() {
+							templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+							if templ_7745c5c3_Err == nil {
+								templ_7745c5c3_Err = templ_7745c5c3_BufErr
+							}
+						}()
+					}
+					ctx = templ.InitializeContext(ctx)
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<span>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var11 string
+					templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx).ChallengeLiveDemo)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 50, Col: 43}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</span>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = icons.OpenNewTabIcon().Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					return templ_7745c5c3_Err
+				})
+				templ_7745c5c3_Err = LinkItem(challenge.AppLink, "inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-sm text-zinc-300 transition-colors hover:bg-white/5").Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</footer>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		if string(challenge.AppLink) != "" {
-			templ_7745c5c3_Var9 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-				if !templ_7745c5c3_IsBuffer {
-					defer func() {
-						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-						if templ_7745c5c3_Err == nil {
-							templ_7745c5c3_Err = templ_7745c5c3_BufErr
-						}
-					}()
-				}
-				ctx = templ.InitializeContext(ctx)
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<span>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var10 string
-				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx).ChallengeLiveDemo)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/challengeCard.templ`, Line: 45, Col: 42}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</span>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = icons.OpenNewTabIcon().Render(ctx, templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				return templ_7745c5c3_Err
-			})
-			templ_7745c5c3_Err = LinkItem(challenge.AppLink, "inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-sm text-zinc-300 transition-colors hover:bg-white/5").Render(templ.WithChildren(ctx, templ_7745c5c3_Var9), templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</footer></article>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</article>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/db/constants/challenges.go
+++ b/internal/db/constants/challenges.go
@@ -42,13 +42,13 @@ func buildChallenge(n challengeNeutral, p challengeProse) Challenge {
 }
 
 // --- neutral facts (shared across locales) ----------------------------------
+// Ordered by outcome (the strongest third-party verdict first), not by date.
 
 var (
-	inditexN = challengeNeutral{
-		Company:  "Inditex",
-		Duration: 7,
-		RepoLink: "https://github.com/AslanSN/zara-web-challenge",
-		AppLink:  "",
+	debosChN = challengeNeutral{
+		Company:   "Debos",
+		Duration:  0, // live interview, not a timed take-home
+		Highlight: true,
 	}
 	nivimuChN = challengeNeutral{
 		Company:   "Nivimu",
@@ -56,12 +56,6 @@ var (
 		Highlight: true,
 		RepoLink:  "https://github.com/AslanSN/nivimu-front-codetest",
 		AppLink:   "https://aslansn.github.io/nivimu-front-codetest/",
-	}
-	arupN = challengeNeutral{
-		Company:  "Arup",
-		Duration: 7,
-		RepoLink: "https://github.com/AslanSN/arup-technicalTest",
-		AppLink:  "https://arup-technical-test-deploy.vercel.app/",
 	}
 	logitravelN = challengeNeutral{
 		Company:   "Logitravel",
@@ -75,23 +69,23 @@ var (
 // --- translatable copy, per locale ------------------------------------------
 
 var (
-	inditexEN = challengeProse{
-		Title:       "Zara Marvel Web Challenge",
-		State:       "Process stopped prior to review of my technical proof",
-		Dates:       "From 1 to 8 August 2024",
-		Description: "Marvel character explorer (list, search, detail, favorites) in Next.js + TypeScript. State via Context + useReducer (no Redux), favorites persisted to localStorage, Vitest tests and Husky pre-commit hooks.",
+	debosChEN = challengeProse{
+		Title:       "Debos — Live problem-solving interview",
+		State:       "Hired on the spot",
+		Dates:       "October 2024",
+		Description: "Two-part technical interview; the real test was a design problem — a search box hitting a backend with highly variable latency: how do you handle it? My answer, three layers: a minimum query length, a 200–500 ms debounce, and an AbortController cancelling the in-flight request so a slower earlier response can't overwrite a newer one — the classic typeahead race condition. Hired on the spot; joined as an external consultant, then moved in-house. I later shipped exactly this in production — a full-stack device search (React + .NET + PostgreSQL trigram indexes).",
 	}
-	inditexES = challengeProse{
-		Title:       "Zara Marvel Web Challenge",
-		State:       "Proceso detenido antes de revisar mi prueba técnica",
-		Dates:       "Del 1 al 8 de agosto de 2024",
-		Description: "Explorador de personajes de Marvel (lista, búsqueda, detalle, favoritos) en Next.js + TypeScript. Estado con Context + useReducer (sin Redux), favoritos persistidos en localStorage, tests con Vitest y hooks pre-commit con Husky.",
+	debosChES = challengeProse{
+		Title:       "Debos — Entrevista de resolución de problemas",
+		State:       "Contratado en el acto",
+		Dates:       "Octubre de 2024",
+		Description: "Entrevista técnica en dos partes; la de verdad era un problema de diseño — un buscador que ataca un backend de latencia muy variable: ¿cómo lo gestionas? Mi respuesta, tres capas: un mínimo de caracteres, un debounce de 200–500 ms y un AbortController que cancela la petición en vuelo para que una respuesta anterior más lenta no sobrescriba a una más nueva — la clásica race condition de un typeahead. Contratado en el acto; entré como consultor externo y luego pasé a plantilla. Después construí exactamente esto en producción — un buscador de dispositivos full-stack (React + .NET + índices trigram en PostgreSQL).",
 	}
-	inditexFR = challengeProse{
-		Title:       "Zara Marvel Web Challenge",
-		State:       "Processus interrompu avant l'examen de mon test technique",
-		Dates:       "Du 1er au 8 août 2024",
-		Description: "Explorateur de personnages Marvel (liste, recherche, détail, favoris) en Next.js + TypeScript. État via Context + useReducer (sans Redux), favoris persistés dans localStorage, tests Vitest et hooks pre-commit avec Husky.",
+	debosChFR = challengeProse{
+		Title:       "Debos — Entretien de résolution de problèmes",
+		State:       "Embauché sur-le-champ",
+		Dates:       "Octobre 2024",
+		Description: "Entretien technique en deux parties ; le vrai test était un problème de conception — un champ de recherche interrogeant un backend à latence très variable : comment le gérer ? Ma réponse, trois couches : un minimum de caractères, un debounce de 200–500 ms et un AbortController qui annule la requête en cours pour qu'une réponse antérieure plus lente n'écrase pas une plus récente — la classique race condition d'un typeahead. Embauché sur-le-champ ; arrivé comme consultant externe, puis passé en interne. J'ai ensuite construit exactement cela en production — une recherche d'appareils full-stack (React + .NET + index trigram PostgreSQL).",
 	}
 
 	nivimuChEN = challengeProse{
@@ -113,63 +107,42 @@ var (
 		Description: "Tableau de données utilisateurs filtrable et triable avec une carte de résumé en temps réel qui se resynchronise avec la première ligne au fil des tris et filtres. React + TypeScript + Redux Toolkit + Ant Design — livré en une seule journée.",
 	}
 
-	arupEN = challengeProse{
-		Title:       "Arup Technical Test",
-		State:       "Not enough experience",
-		Dates:       "From 7 to 14 June 2022",
-		Description: "Construction-site communications manager: a three-panel UI — discipline/status filter sidebar, sortable questions list and detail view. React (Flux) + SASS, SOLID and documented components.",
-	}
-	arupES = challengeProse{
-		Title:       "Prueba técnica de Arup",
-		State:       "Experiencia insuficiente",
-		Dates:       "Del 7 al 14 de junio de 2022",
-		Description: "Gestor de comunicaciones de obra: una UI de tres paneles — barra lateral de filtros por disciplina/estado, lista ordenable de preguntas y vista de detalle. React (Flux) + SASS, SOLID y componentes documentados.",
-	}
-	arupFR = challengeProse{
-		Title:       "Test technique Arup",
-		State:       "Expérience insuffisante",
-		Dates:       "Du 7 au 14 juin 2022",
-		Description: "Gestionnaire de communications de chantier : une UI à trois panneaux — barre latérale de filtres par discipline/statut, liste de questions triable et vue de détail. React (Flux) + SASS, SOLID et composants documentés.",
-	}
-
 	logitravelEN = challengeProse{
 		Title:       "Logitravel - PrimeIT Technical Proof",
-		State:       "Candidate with best technical skills",
+		State:       "Best technical candidate",
 		Dates:       "From 1 to 4 July 2022",
 		Description: "Text-list manager with add / select / delete and full undo–redo. React + Redux Toolkit + styled-components, a centralized design-token system and SOLID structure — built in a 3-day proof.",
 	}
 	logitravelES = challengeProse{
 		Title:       "Logitravel - Prueba técnica de PrimeIT",
-		State:       "Candidato con las mejores competencias técnicas",
+		State:       "Mejor candidato técnico",
 		Dates:       "Del 1 al 4 de julio de 2022",
 		Description: "Gestor de listas de texto con añadir / seleccionar / borrar y deshacer–rehacer completo. React + Redux Toolkit + styled-components, un sistema centralizado de design tokens y estructura SOLID — construido en una prueba de 3 días.",
 	}
 	logitravelFR = challengeProse{
 		Title:       "Logitravel - Test technique PrimeIT",
-		State:       "Candidat aux meilleures compétences techniques",
+		State:       "Meilleur candidat technique",
 		Dates:       "Du 1er au 4 juillet 2022",
 		Description: "Gestionnaire de listes de texte avec ajouter / sélectionner / supprimer et annuler–rétablir complet. React + Redux Toolkit + styled-components, un système centralisé de design tokens et une structure SOLID — construit lors d'un test de 3 jours.",
 	}
 )
 
-// Challenges is the technical-test list per locale.
+// Challenges is the technical-test list per locale, ordered by outcome:
+// Debos (hired on the spot) → Nivimu (hired) → Logitravel (best technical candidate).
 var Challenges = map[i18n.Locale][]Challenge{
 	i18n.EN: {
-		buildChallenge(inditexN, inditexEN),
+		buildChallenge(debosChN, debosChEN),
 		buildChallenge(nivimuChN, nivimuChEN),
-		buildChallenge(arupN, arupEN),
 		buildChallenge(logitravelN, logitravelEN),
 	},
 	i18n.ES: {
-		buildChallenge(inditexN, inditexES),
+		buildChallenge(debosChN, debosChES),
 		buildChallenge(nivimuChN, nivimuChES),
-		buildChallenge(arupN, arupES),
 		buildChallenge(logitravelN, logitravelES),
 	},
 	i18n.FR: {
-		buildChallenge(inditexN, inditexFR),
+		buildChallenge(debosChN, debosChFR),
 		buildChallenge(nivimuChN, nivimuChFR),
-		buildChallenge(arupN, arupFR),
 		buildChallenge(logitravelN, logitravelFR),
 	},
 }

--- a/internal/i18n/dict.go
+++ b/internal/i18n/dict.go
@@ -72,7 +72,7 @@ var dicts = map[Locale]Dict{
 		SectionAbout:      "About",
 		SectionSkills:     "Skills",
 		SectionExperience: "Experience",
-		SectionChallenges: "Challenges",
+		SectionChallenges: "The verdict",
 
 		Share:      "Share",
 		Contact:    "Contact",
@@ -82,7 +82,7 @@ var dicts = map[Locale]Dict{
 		HeroRole:    "Senior Full-Stack Engineer",
 		HeroTagline: "AI-native · React / Next.js + .NET · platform",
 
-		ChallengesIntro:     "Company technical tests — how I approach an unfamiliar problem under a deadline, and how each one landed.",
+		ChallengesIntro:     "Company technical tests under a deadline — how I approach an unfamiliar problem, and the verdict each one earned.",
 		ChallengeRepository: "Repository",
 		ChallengeLiveDemo:   "Live demo",
 		Day:                 "day",
@@ -118,7 +118,7 @@ var dicts = map[Locale]Dict{
 		SectionAbout:      "Sobre mí",
 		SectionSkills:     "Competencias",
 		SectionExperience: "Experiencia",
-		SectionChallenges: "Pruebas técnicas",
+		SectionChallenges: "El veredicto",
 
 		Share:      "Compartir",
 		Contact:    "Contacto",
@@ -128,7 +128,7 @@ var dicts = map[Locale]Dict{
 		HeroRole:    "Ingeniero Full-Stack Senior",
 		HeroTagline: "AI-native · React / Next.js + .NET · plataforma",
 
-		ChallengesIntro:     "Pruebas técnicas de empresas — cómo abordo un problema desconocido contra reloj, y en qué acabó cada una.",
+		ChallengesIntro:     "Pruebas técnicas de empresa contra reloj — cómo abordo un problema desconocido, y el veredicto que se llevó cada una.",
 		ChallengeRepository: "Repositorio",
 		ChallengeLiveDemo:   "Demo en vivo",
 		Day:                 "día",
@@ -164,7 +164,7 @@ var dicts = map[Locale]Dict{
 		SectionAbout:      "À propos",
 		SectionSkills:     "Compétences",
 		SectionExperience: "Expérience",
-		SectionChallenges: "Tests techniques",
+		SectionChallenges: "Le verdict",
 
 		Share:      "Partager",
 		Contact:    "Contact",
@@ -174,7 +174,7 @@ var dicts = map[Locale]Dict{
 		HeroRole:    "Ingénieur Full-Stack Senior",
 		HeroTagline: "AI-native · React / Next.js + .NET · plateforme",
 
-		ChallengesIntro:     "Tests techniques d'entreprises — comment j'aborde un problème inconnu sous contrainte de délai, et le résultat de chacun.",
+		ChallengesIntro:     "Tests techniques d'entreprise sous contrainte de délai — comment j'aborde un problème inconnu, et le verdict obtenu pour chacun.",
 		ChallengeRepository: "Dépôt",
 		ChallengeLiveDemo:   "Démo en ligne",
 		Day:                 "jour",


### PR DESCRIPTION
## What

Reframes the technical-tests section from chronological to **outcome-first** and retitles it **"The verdict" / "El veredicto" / "Le verdict"** — leading with third-party verdicts on technical skill rather than mere activity.

- **Debos added as #1**: live problem-solving interview — a search box over a variable-latency backend, solved with min query length + 200–500 ms debounce + `AbortController` to kill the typeahead race condition; hired on the spot; the same search later shipped in production (React + .NET + PostgreSQL trigram indexes).
- **Ordered by result**: Debos (hired on the spot) → Nivimu (hired) → Logitravel (best technical candidate).
- **Archived** Zara/Inditex (process stopped) and Arup (not selected) — the section now shows only positive third-party verdicts. Code still lives in their own repos + git history.
- Shortened the Logitravel badge to "Best technical candidate".
- `challengeCard`: supports entries with no duration and no links (omits the "· N days" suffix and renders no empty footer).
- Section title + intro updated across EN/ES/FR.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — all green (incl. `dict_test`, which fails the build if any locale leaves a field empty).
- Rendered locally and verified via HTTP in EN/ES/FR: new title/badges present, Zara/Arup gone.
- Live-demo URLs (Nivimu, Logitravel) return 200.

Out of scope (separate PR): homogenising the older experience entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)