### PR TITLE
feat(experience): compress older roles to one line, elevate Nivimu

### DIFF
--- a/app/components/experienceCard.templ
+++ b/app/components/experienceCard.templ
@@ -1,6 +1,8 @@
 package components
 
 import (
+	"strings"
+
 	"github.com/AslanSN/CurriculumVitae/internal/db/constants"
 	"github.com/AslanSN/CurriculumVitae/i18n"
 )
@@ -32,18 +34,29 @@ templ ExperienceCard(workplace constants.ExperienceStruct) {
 				</div>
 				<p class="font-mono text-sm text-zinc-500">{ workplace.Contract } · { workplace.RangeDate }</p>
 			</div>
-			<div class="grid gap-6 sm:grid-cols-2">
+			if workplace.Compact {
 				<div>
-					@List(i18n.T(ctx).Stack, workplace.Techs)
+					if len(workplace.Responsabilities) > 0 {
+						<p class="text-sm leading-relaxed text-zinc-300">{ workplace.Responsabilities[0] }</p>
+					}
+					if len(workplace.Techs) > 0 {
+						<p class="mt-2 font-mono text-xs text-zinc-500">{ strings.Join(workplace.Techs, " · ") }</p>
+					}
 				</div>
-				<div>
-					@List(i18n.T(ctx).WhatIDid, workplace.Responsabilities)
+			} else {
+				<div class="grid gap-6 sm:grid-cols-2">
+					<div>
+						@List(i18n.T(ctx).Stack, workplace.Techs)
+					</div>
+					<div>
+						@List(i18n.T(ctx).WhatIDid, workplace.Responsabilities)
+					</div>
 				</div>
-			</div>
-			if len(workplace.Extra) > 0 {
-				<div class="border-t border-white/10 pt-4">
-					@List(i18n.T(ctx).Highlights, workplace.Extra)
-				</div>
+				if len(workplace.Extra) > 0 {
+					<div class="border-t border-white/10 pt-4">
+						@List(i18n.T(ctx).Highlights, workplace.Extra)
+					</div>
+				}
 			}
 		</div>
 	</li>

--- a/app/components/experienceCard_templ.go
+++ b/app/components/experienceCard_templ.go
@@ -9,6 +9,8 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
+	"strings"
+
 	"github.com/AslanSN/CurriculumVitae/i18n"
 	"github.com/AslanSN/CurriculumVitae/internal/db/constants"
 )
@@ -41,7 +43,7 @@ func ExperienceCard(workplace constants.ExperienceStruct) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(workplace.Company + "Experience")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 9, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 11, Col: 42}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -59,7 +61,7 @@ func ExperienceCard(workplace constants.ExperienceStruct) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(string(workplace.ImageSource))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 16, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 18, Col: 42}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -72,7 +74,7 @@ func ExperienceCard(workplace constants.ExperienceStruct) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(workplace.ImageAlternative)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 17, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 19, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -103,7 +105,7 @@ func ExperienceCard(workplace constants.ExperienceStruct) templ.Component {
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(workplace.Company)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 24, Col: 28}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 26, Col: 28}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
@@ -119,7 +121,7 @@ func ExperienceCard(workplace constants.ExperienceStruct) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(workplace.Company)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 27, Col: 27}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 29, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -133,7 +135,7 @@ func ExperienceCard(workplace constants.ExperienceStruct) templ.Component {
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(workplace.CompanyType)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 30, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 32, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
@@ -146,7 +148,7 @@ func ExperienceCard(workplace constants.ExperienceStruct) templ.Component {
 		var templ_7745c5c3_Var9 string
 		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(workplace.Position)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 30, Col: 88}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 32, Col: 88}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
@@ -159,7 +161,7 @@ func ExperienceCard(workplace constants.ExperienceStruct) templ.Component {
 		var templ_7745c5c3_Var10 string
 		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(workplace.Contract)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 33, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 35, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
@@ -172,44 +174,97 @@ func ExperienceCard(workplace constants.ExperienceStruct) templ.Component {
 		var templ_7745c5c3_Var11 string
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(workplace.RangeDate)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 33, Col: 94}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 35, Col: 94}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p></div><div class=\"grid gap-6 sm:grid-cols-2\"><div>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = List(i18n.T(ctx).Stack, workplace.Techs).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div><div>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = List(i18n.T(ctx).WhatIDid, workplace.Responsabilities).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div></div>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if len(workplace.Extra) > 0 {
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"border-t border-white/10 pt-4\">")
+		if workplace.Compact {
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = List(i18n.T(ctx).Highlights, workplace.Extra).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
+			if len(workplace.Responsabilities) > 0 {
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<p class=\"text-sm leading-relaxed text-zinc-300\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var12 string
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(workplace.Responsabilities[0])
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 40, Col: 86}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			if len(workplace.Techs) > 0 {
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<p class=\"mt-2 font-mono text-xs text-zinc-500\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var13 string
+				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(strings.Join(workplace.Techs, " · "))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `app/components/experienceCard.templ`, Line: 43, Col: 93}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
+			}
+		} else {
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"grid gap-6 sm:grid-cols-2\"><div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = List(i18n.T(ctx).Stack, workplace.Techs).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div><div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = List(i18n.T(ctx).WhatIDid, workplace.Responsabilities).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if len(workplace.Extra) > 0 {
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"border-t border-white/10 pt-4\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = List(i18n.T(ctx).Highlights, workplace.Extra).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div></li>")

--- a/internal/db/constants/experience.go
+++ b/internal/db/constants/experience.go
@@ -10,6 +10,9 @@ type ExperienceStruct struct {
 	Company, CompanyType, Contract, Position, RangeDate, ImageAlternative string
 	Link, ImageSource                                                     templ.SafeURL
 	Techs, Responsabilities, Extra                                        []string
+	// Compact renders the workplace as a single achievement line (older,
+	// less-central roles) instead of the full Stack / What-I-did card.
+	Compact bool
 }
 
 // expNeutral holds the language-independent identity of a workplace. It is
@@ -18,6 +21,7 @@ type expNeutral struct {
 	Company, RangeDate, ImageAlternative string
 	ImageSource, Link                    templ.SafeURL
 	Techs                                []string
+	Compact                              bool
 }
 
 // expProse holds the translatable copy for a workplace.
@@ -34,6 +38,7 @@ func buildExp(n expNeutral, p expProse) ExperienceStruct {
 		ImageSource:      n.ImageSource,
 		Link:             n.Link,
 		Techs:            n.Techs,
+		Compact:          n.Compact,
 		CompanyType:      p.CompanyType,
 		Contract:         p.Contract,
 		Position:         p.Position,
@@ -59,7 +64,7 @@ var (
 		ImageSource:      helpers.RepoURL + "/images/nivimu.svg",
 		ImageAlternative: "nivimu logo consists in a blue capital n with its name bellow",
 		Link:             "https://nivimu.com/",
-		Techs:            []string{"React", "Ant Design", "Emotion", "Redux", "Redux Saga", "TanStack (React) Query", "Mockoon", "Sentry", "bitDev", "GitLab"},
+		Techs:            []string{"React", "TypeScript", "Ant Design", "Emotion", "Redux", "Redux Saga", "TanStack Query", "Bit", "Mockoon", "Sentry"},
 	}
 	memorizameN = expNeutral{
 		Company:          "Memorizame",
@@ -67,7 +72,8 @@ var (
 		ImageSource:      helpers.RepoURL + "/images/memorizame.webp",
 		ImageAlternative: "memorizeme icon, three M in three different colors, one before another getting smaller",
 		Link:             "",
-		Techs:            []string{"Svelte", "Figma", "Miro", "Supabase", "TypeScript", "JavaScript", "Github"},
+		Techs:            []string{"Svelte", "Supabase", "TypeScript", "Figma"},
+		Compact:          true,
 	}
 	integroN = expNeutral{
 		Company:          "Íntegro",
@@ -75,7 +81,8 @@ var (
 		ImageSource:      helpers.RepoURL + "/images/integro.webp",
 		ImageAlternative: "integro writed in black with the o in blue",
 		Link:             "",
-		Techs:            []string{"Qwik", "Figma", "Illustrator", "TypeScript"},
+		Techs:            []string{"Qwik", "TypeScript", "Figma"},
+		Compact:          true,
 	}
 	attlosN = expNeutral{
 		Company:          "Attlos",
@@ -83,7 +90,8 @@ var (
 		ImageSource:      helpers.RepoURL + "/images/attlos.webp",
 		ImageAlternative: "Attlos logo",
 		Link:             "https://www.youtube.com/channel/UC7hs7M2NfwWizyRIZkkOXVA",
-		Techs:            []string{"Styled-Components", "TypeScript", "React", "Flux", "Redux", "Azure", "Git"},
+		Techs:            []string{"TypeScript", "React", "Redux", "Azure"},
+		Compact:          true,
 	}
 )
 
@@ -140,112 +148,94 @@ var (
 	}
 
 	nivimuEN = expProse{
-		CompanyType:      "Startup",
-		Contract:         "Employee",
-		Position:         "Frontend",
-		Responsabilities: []string{"Code review", "Branch self-approval", "QA of UX", "Freedom of choice of tasks", "Deadlines"},
-		Extra: []string{
-			"Specializing in Time Zones, Ant Design and React Query",
-			"Intense teamwork",
-			"Cutting edge startup",
-			"Complex application",
-			"Short deadlines",
-			"Agile, Lean, Extreme Programming",
+		CompanyType: "HR PWA startup",
+		Contract:    "Employee",
+		Position:    "Frontend Developer",
+		Responsabilities: []string{
+			"Owned features end to end with high individual responsibility — code review, branch self-approval, UX QA",
+			"Led the JavaScript → TypeScript migration across a large-scale HR PWA",
+			"Built an internal component library, design system and micro-frontends (Bit)",
+			"Handled time-zone-correct scheduling across the product",
 		},
 	}
 	nivimuES = expProse{
-		CompanyType:      "Startup",
-		Contract:         "Empleado",
-		Position:         "Frontend",
-		Responsabilities: []string{"Code review", "Autoaprobación de ramas", "QA de la UX", "Libertad para elegir tareas", "Plazos"},
-		Extra: []string{
-			"Especialización en zonas horarias, Ant Design y React Query",
-			"Trabajo en equipo intenso",
-			"Startup puntera",
-			"Aplicación compleja",
-			"Plazos ajustados",
-			"Agile, Lean, Extreme Programming",
+		CompanyType: "Startup de PWA de RR. HH.",
+		Contract:    "Empleado",
+		Position:    "Desarrollador Frontend",
+		Responsabilities: []string{
+			"Ownership de features de principio a fin con alta responsabilidad individual — code review, autoaprobación de ramas, QA de UX",
+			"Lideré la migración JavaScript → TypeScript en una PWA de RR. HH. a gran escala",
+			"Construí una biblioteca de componentes interna, design system y micro-frontends (Bit)",
+			"Gestioné el manejo correcto de zonas horarias en todo el producto",
 		},
 	}
 	nivimuFR = expProse{
-		CompanyType:      "Startup",
-		Contract:         "Salarié",
-		Position:         "Frontend",
-		Responsabilities: []string{"Code review", "Auto-approbation des branches", "QA de l'UX", "Liberté de choix des tâches", "Délais"},
-		Extra: []string{
-			"Spécialisation en fuseaux horaires, Ant Design et React Query",
-			"Travail d'équipe intense",
-			"Startup de pointe",
-			"Application complexe",
-			"Délais serrés",
-			"Agile, Lean, Extreme Programming",
+		CompanyType: "Startup PWA RH",
+		Contract:    "Salarié",
+		Position:    "Développeur Frontend",
+		Responsabilities: []string{
+			"Ownership des fonctionnalités de bout en bout avec forte responsabilité individuelle — code review, auto-approbation des branches, QA de l'UX",
+			"Piloté la migration JavaScript → TypeScript sur une PWA RH à grande échelle",
+			"Construit une bibliothèque de composants interne, un design system et des micro-frontends (Bit)",
+			"Assuré la gestion correcte des fuseaux horaires dans tout le produit",
 		},
 	}
 
 	memorizameEN = expProse{
-		CompanyType:      "Project",
+		CompanyType:      "Freelance project",
 		Contract:         "Freelancer",
 		Position:         "Full stack",
-		Responsabilities: []string{"Design system", "UI/UX", "Architecture", "Layout", "Single frontend developer"},
-		Extra:            []string{"App for learning with supermemo methodology"},
+		Responsabilities: []string{"Sole frontend for a spaced-repetition learning app (SuperMemo method) — design system, UI/UX and architecture."},
 	}
 	memorizameES = expProse{
-		CompanyType:      "Proyecto",
+		CompanyType:      "Proyecto freelance",
 		Contract:         "Freelance",
 		Position:         "Full stack",
-		Responsabilities: []string{"Design system", "UI/UX", "Arquitectura", "Maquetación", "Único desarrollador frontend"},
-		Extra:            []string{"App para aprender con la metodología SuperMemo"},
+		Responsabilities: []string{"Único frontend de una app de aprendizaje por repetición espaciada (método SuperMemo) — design system, UI/UX y arquitectura."},
 	}
 	memorizameFR = expProse{
-		CompanyType:      "Projet",
+		CompanyType:      "Projet freelance",
 		Contract:         "Freelance",
 		Position:         "Full stack",
-		Responsabilities: []string{"Design system", "UI/UX", "Architecture", "Intégration", "Seul développeur frontend"},
-		Extra:            []string{"Application d'apprentissage avec la méthodologie SuperMemo"},
+		Responsabilities: []string{"Seul frontend d'une application d'apprentissage par répétition espacée (méthode SuperMemo) — design system, UI/UX et architecture."},
 	}
 
 	integroEN = expProse{
 		CompanyType:      "Startup",
 		Contract:         "Freelancer",
-		Position:         "Full stack and more",
-		Responsabilities: []string{"Design system", "UI/UX", "Architecture", "Layout", "Single software developer", "Branding", "Tech analyst"},
-		Extra:            []string{"Thanks to my vision I have helped to create the identity of the Íntegro company"},
+		Position:         "Full stack",
+		Responsabilities: []string{"Sole developer and technical analyst for a startup — company site end to end, design system and branding."},
 	}
 	integroES = expProse{
 		CompanyType:      "Startup",
 		Contract:         "Freelance",
-		Position:         "Full stack y más",
-		Responsabilities: []string{"Design system", "UI/UX", "Arquitectura", "Maquetación", "Único desarrollador de software", "Branding", "Analista técnico"},
-		Extra:            []string{"Con mi visión ayudé a crear la identidad de la empresa Íntegro"},
+		Position:         "Full stack",
+		Responsabilities: []string{"Único desarrollador y analista técnico de una startup — web de empresa de principio a fin, design system y branding."},
 	}
 	integroFR = expProse{
 		CompanyType:      "Startup",
 		Contract:         "Freelance",
-		Position:         "Full stack et plus",
-		Responsabilities: []string{"Design system", "UI/UX", "Architecture", "Intégration", "Seul développeur logiciel", "Branding", "Analyste technique"},
-		Extra:            []string{"Grâce à ma vision, j'ai contribué à créer l'identité de l'entreprise Íntegro"},
+		Position:         "Full stack",
+		Responsabilities: []string{"Seul développeur et analyste technique d'une startup — site d'entreprise de bout en bout, design system et branding."},
 	}
 
 	attlosEN = expProse{
 		CompanyType:      "Startup",
 		Contract:         "Intern",
 		Position:         "Front End",
-		Responsabilities: []string{"Team Lead", "Deadlines", "Architecture"},
-		Extra:            []string{"Implementing Tokenizations", "Agile Scrum"},
+		Responsabilities: []string{"First professional TypeScript/React role — built product features in an Agile/Scrum team."},
 	}
 	attlosES = expProse{
 		CompanyType:      "Startup",
 		Contract:         "Becario",
 		Position:         "Front End",
-		Responsabilities: []string{"Team Lead", "Plazos", "Arquitectura"},
-		Extra:            []string{"Implementación de tokenizaciones", "Agile Scrum"},
+		Responsabilities: []string{"Primer puesto profesional con TypeScript/React — desarrollé features de producto en un equipo Agile/Scrum."},
 	}
 	attlosFR = expProse{
 		CompanyType:      "Startup",
 		Contract:         "Stagiaire",
 		Position:         "Front End",
-		Responsabilities: []string{"Team Lead", "Délais", "Architecture"},
-		Extra:            []string{"Implémentation de tokenisations", "Agile Scrum"},
+		Responsabilities: []string{"Premier poste professionnel en TypeScript/React — développé des fonctionnalités produit dans une équipe Agile/Scrum."},
 	}
 )
 


### PR DESCRIPTION
Finishes the Phase-A curation of the **Experience** section. Direction chosen by Alan: *compress the old roles to one line each*; verified against the finalized CV (`~/Documents/cv/cv-alan-fullstack-{en,es}.txt`).

## What changed
- **Nivimu → Debos standard** (rich card): end-to-end ownership (code review, branch self-approval, UX QA), the **JS→TypeScript migration**, internal component library / design system / **micro-frontends (Bit)**, and time-zone-correct scheduling. `TypeScript` added to its stack; type/title aligned to the CV ("HR PWA startup · Frontend Developer").
- **Memorizame / Íntegro / Attlos → one line each** (new `Compact` card variant): a single achievement line + a muted monospace tech row. Mirrors the CV's "EARLIER" block and creates clear visual hierarchy (2 rich cards → 3 light one-liners).
- **Dropped the weak/junior copy**: "Freedom of choice of tasks", "Intense teamwork", "Cutting edge startup", "Thanks to my vision…", intern-labelled "Team Lead".
- All copy authored across **EN / ES / FR**.

## Implementation
- `Compact bool` on `ExperienceStruct` (+ neutral struct), threaded via `buildExp`. Template branches: compact = one line + `strings.Join(techs, " · ")`; non-compact keeps the Stack / What-I-did grid + Highlights. No new i18n `Dict` fields, no CSS changes needed (reuses existing classes).

## Verification (run this turn)
- `go build ./...`, `go vet ./...`, `go test ./...` — all green.
- Rendered **/**, **/es**, **/fr** locally: new copy present, compact tech rows correct, old copy gone.
- Visual pass (tall-viewport screenshot): hierarchy reads as intended.

## ⚠️ One thing to reconcile
**Íntegro stack**: the site data says **Qwik**; your 2026 CV says **React/Node**. I kept the site's existing `Qwik · TypeScript · Figma` (didn't want to silently rewrite a factual claim). The one-line sentence is stack-agnostic, so it's correct either way — but fix the tech row's one word if the CV is the accurate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)